### PR TITLE
fix(linux): prevent black window corners

### DIFF
--- a/frontend/src/services/wails-api.js
+++ b/frontend/src/services/wails-api.js
@@ -1,5 +1,5 @@
 import { CancelModelDiscovery, CheckEnvVar, CheckForUpdate, ContinueSession, CreateProvider, DeleteGlobalSkill, DeleteModels, DeleteProvider, DeleteSession, ExecuteLaunchOMP, FetchModels, GetAppState, GetModelsDeleteImpact, GetProviderDeleteImpact, ImportDiscoveredModels, InstallUpdate, ListGlobalSkills, ListSessions, MarkUpdateChecked, OpenConfigFolder, SaveModel, SetSelectedModel, SetSelectedProvider, TestModel, UpdateModelRoles, UpdateProvider, UpdateSettings, ListWSLDistros, ResolveWSLPaths, ResolveNativePaths, } from "../../wailsjs/go/main/App";
-import { BrowserOpenURL, Quit, WindowMinimise, WindowToggleMaximise, EventsOn } from "../../wailsjs/runtime/runtime";
+import { BrowserOpenURL, Quit, WindowMinimise, WindowSetBackgroundColour, WindowToggleMaximise, EventsOn } from "../../wailsjs/runtime/runtime";
 
 export class WailsApi {
   onConfigChanged(callback) { return EventsOn("omp:config-changed", callback); }
@@ -36,6 +36,7 @@ export class WailsApi {
   openConfigFolder() { return OpenConfigFolder(); }
   openExternalURL(url) { BrowserOpenURL(url); }
   minimiseWindow() { WindowMinimise(); }
+  setWindowBackgroundColour(red, green, blue, alpha) { WindowSetBackgroundColour(red, green, blue, alpha); }
   closeWindow() { Quit(); }
   toggleMaximiseWindow() { WindowToggleMaximise(); }
 }

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -7,7 +7,7 @@ body {
   margin: 0;
   min-height: 100%;
   font-family: var(--font-ui);
-  background: transparent;
+  background: var(--app-bg);
   color: var(--ink);
 }
 

--- a/frontend/src/theme/theme-manager.js
+++ b/frontend/src/theme/theme-manager.js
@@ -1,4 +1,8 @@
 const MODES = new Set(["light", "dark", "system"]);
+const WINDOW_BACKGROUNDS = {
+  light: [243, 245, 247, 255],
+  dark: [15, 17, 21, 255],
+};
 
 export function normalizeThemeMode(mode) {
   return MODES.has(mode) ? mode : "system";
@@ -36,6 +40,7 @@ export class ThemeManager {
     document.documentElement.dataset.theme = theme;
     document.body.dataset.theme = theme;
     document.documentElement.style.colorScheme = theme;
+    this.api.setWindowBackgroundColour?.(...WINDOW_BACKGROUNDS[theme]);
   }
 
   async toggle(button) {

--- a/frontend/test/theme-manager.test.js
+++ b/frontend/test/theme-manager.test.js
@@ -25,12 +25,17 @@ test("theme switcher exposes one three-state control", () => {
 function themeHarness(updateSettings) {
   const attributes = new Map();
   const classes = new Set();
+  const windowBackgrounds = [];
   const root = { dataset: {}, style: {} };
   globalThis.window = {};
   globalThis.document = { documentElement: root, body: { dataset: {} } };
   const state = { settings: { theme: "light", ompCommand: "omp" }, presets: [], modal: null };
   const store = { getState: () => state, setState(update) { Object.assign(state, update(state)); } };
-  const api = { applyWindowTheme() {}, updateSettings };
+  const api = {
+    applyWindowTheme() {},
+    setWindowBackgroundColour: (...colour) => windowBackgrounds.push(colour),
+    updateSettings
+  };
   const button = {
     getBoundingClientRect: () => ({ left: 740, top: 10, width: 34, height: 34 }),
     setAttribute: (name, value) => attributes.set(name, value),
@@ -39,8 +44,16 @@ function themeHarness(updateSettings) {
   };
   const manager = new ThemeManager({ api, store, media: { matches: false, addEventListener() {} } });
   manager.initialise(state.settings);
-  return { manager, state, button, attributes, classes };
+  return { manager, state, button, attributes, classes, windowBackgrounds };
 }
+
+test("theme application keeps the native Linux window background opaque", () => {
+  const harness = themeHarness(async (settings) => ({ settings }));
+
+  assert.deepEqual(harness.windowBackgrounds, [[243, 245, 247, 255]]);
+  harness.manager.applyResolved("dark");
+  assert.deepEqual(harness.windowBackgrounds.at(-1), [15, 17, 21, 255]);
+});
 
 test("theme toggle persists once and blocks re-entry while saving", async () => {
   let release;

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 		AssetServer: &assetserver.Options{
 			Assets: assets,
 		},
-		BackgroundColour: &options.RGBA{R: 0, G: 0, B: 0, A: 0},
+		BackgroundColour: options.NewRGB(243, 245, 247),
 		OnStartup:        app.startup,
 		OnShutdown:       app.shutdown,
 		Windows: &windowsoptions.Options{


### PR DESCRIPTION
  ## Summary

  Fix black corners in the frameless Linux window.

  - Use an opaque native window background instead of a transparent one.
  - Keep the native window background synchronized with the resolved light or dark theme.
  - Use the application surface color for the document root instead of a transparent background.
  - Add regression coverage for native window background synchronization.

  ## Root cause

  On Linux, transparent WebKitGTK pixels exposed outside the rounded application shell
  could be composited as black by the desktop environment. The native window background
  is now opaque and theme-aware, so the rounded corners no longer reveal black pixels.
  
<img width="485" height="195" alt="image" src="https://github.com/user-attachments/assets/6f625db3-f6b2-4535-a025-70c4a90ff11e" />

  ## Testing

  - `npm test` — 17 passing tests
  - Verified the frameless application window no longer shows black corner artifacts